### PR TITLE
feat: :label: Update UploadResponse type

### DIFF
--- a/src/common/bundlr.ts
+++ b/src/common/bundlr.ts
@@ -6,7 +6,7 @@ import { DataItemCreateOptions } from "arbundles";
 import BundlrTransaction from "./transaction";
 import Api from "./api";
 import BigNumber from "bignumber.js";
-import { CreateAndUploadOptions, Currency, FundResponse, UploadResponse, WithdrawalResponse } from "./types";
+import { CreateAndUploadOptions, Currency, FundResponse, UploadReceipt, UploadResponse, WithdrawalResponse } from "./types";
 import { Signer } from "arbundles/src/signing";
 import { Readable } from "stream";
 
@@ -65,7 +65,7 @@ export default abstract class Bundlr {
         return this.utils.getPrice(this.currency, bytes);
     }
 
-    public async verifyReceipt(receipt: Required<UploadResponse>) {
+    public async verifyReceipt(receipt: UploadReceipt): Promise<boolean> {
         return Utils.verifyReceipt(receipt);
     }
 

--- a/src/common/bundlr.ts
+++ b/src/common/bundlr.ts
@@ -86,7 +86,7 @@ export default abstract class Bundlr {
         return this.currencyConfig.getSigner();
     }
 
-    async upload(data: string | Buffer | Readable, opts?: CreateAndUploadOptions): Promise<UploadResponse> {
+    async upload(data: string | Buffer | Readable, opts?: CreateAndUploadOptions): Promise<UploadResponse | UploadReceipt> {
         return this.uploader.uploadData(data, opts);
     }
 

--- a/src/common/transaction.ts
+++ b/src/common/transaction.ts
@@ -2,7 +2,7 @@ import { createData, DataItem, DataItemCreateOptions } from "arbundles";
 import { Signer } from "arbundles/src/signing";
 import Bundlr from "./bundlr";
 import Crypto from "crypto";
-import { UploadOptions, UploadResponse } from "./types";
+import { UploadOptions, UploadReceipt, UploadResponse } from "./types";
 
 /**
  * Extended DataItem that allows for seamless bundlr operations, such as signing and uploading.
@@ -28,7 +28,7 @@ export default class BundlrTransaction extends DataItem {
         return this.getRaw().length;
     }
 
-    async upload(opts?: UploadOptions): Promise<UploadResponse> {
+    async upload(opts?: UploadOptions): Promise<UploadResponse | UploadReceipt> {
         return (await this.bundlr.uploader.uploadTransaction(this, opts)).data;
     }
 

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -71,31 +71,33 @@ export interface Manifest {
 }
 
 
-export interface UploadResponse {
+export type UploadResponse = UploadResponseBase | UploadReceipt;
+
+
+export type UploadResponseBase = {
     // The ID of the transaction
-    id: string,
-
-    /**
-     * All below (bar timestamp) are optional (requiring the getReceiptSignature option)
-     */
-
-    // The Arweave public key of the node that received the transaction
-    public?: string,
-    // The signature of this receipt
-    signature?: string,
-    // the maximum expected Arweave block height for transaction inclusion
-    deadlineHeight?: number,
-    // List of validator signatures
-    validatorSignatures?: { address: string, signature: string; }[];
+    id: string;
     // The UNIX (MS precision) timestamp of when the node received the Tx. Only optional if the upload receives a `201` error in response to a duplicate transaction upload.
-    timestamp?: number;
-    // The receipt version
-    version?: "1.0.0";
-    // Injected verification function (same as Utils/Bundlr.verifyReceipt) - only present if getReceiptSignature is set.
-    verify?: () => Promise<boolean>;
-}
+    timestamp: number;
+};
 
-export type UploadReceipt = Required<UploadResponse>;
+export type UploadReceipt = {
+    /**
+    * All below (bar timestamp) are optional (requiring the getReceiptSignature option)
+    */
+    // The Arweave public key of the node that received the transaction
+    public: string,
+    // The signature of this receipt
+    signature: string,
+    // the maximum expected Arweave block height for transaction inclusion
+    deadlineHeight: number,
+    // List of validator signatures
+    validatorSignatures: { address: string, signature: string; }[];
+    // The receipt version
+    version: "1.0.0";
+    // Injected verification function (same as Utils/Bundlr.verifyReceipt) - only present if getReceiptSignature is set.
+    verify: () => Promise<boolean>;
+} & UploadResponseBase;
 
 export interface FundResponse {
     reward: string,

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -71,10 +71,7 @@ export interface Manifest {
 }
 
 
-export type UploadResponse = UploadResponseBase | UploadReceipt;
-
-
-export type UploadResponseBase = {
+export type UploadResponse = {
     // The ID of the transaction
     id: string;
     // The UNIX (MS precision) timestamp of when the node received the Tx. Only optional if the upload receives a `201` error in response to a duplicate transaction upload.
@@ -97,7 +94,7 @@ export type UploadReceipt = {
     version: "1.0.0";
     // Injected verification function (same as Utils/Bundlr.verifyReceipt) - only present if getReceiptSignature is set.
     verify: () => Promise<boolean>;
-} & UploadResponseBase;
+} & UploadResponse;
 
 export interface FundResponse {
     reward: string,

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -31,8 +31,8 @@ export default class Uploader {
      * Uploads a given transaction to the bundler
      * @param transaction
      */
-    public async uploadTransaction(transaction: DataItem | Readable | Buffer, opts?: UploadOptions): Promise<AxiosResponse<UploadResponse>> {
-        let res: AxiosResponse<UploadResponse>;
+    public async uploadTransaction(transaction: DataItem | Readable | Buffer, opts?: UploadOptions): Promise<AxiosResponse<UploadResponse | UploadReceipt>> {
+        let res: AxiosResponse<UploadResponse | UploadReceipt>;
         const isDataItem = DataItem.isDataItem(transaction);
         if (this.forceUseChunking || (isDataItem && transaction.getRaw().length >= CHUNKING_THRESHOLD) || !isDataItem) {
             res = await this.chunkedUploader.uploadTransaction(isDataItem ? transaction.getRaw() : transaction, opts);
@@ -65,7 +65,7 @@ export default class Uploader {
         return res;
     }
 
-    public async uploadData(data: string | Buffer | Readable, opts?: CreateAndUploadOptions): Promise<UploadResponse> {
+    public async uploadData(data: string | Buffer | Readable, opts?: CreateAndUploadOptions): Promise<UploadResponse | UploadReceipt> {
         if (typeof data === "string") {
             data = Buffer.from(data);
         }

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -2,7 +2,7 @@ import { createData, DataItem } from "arbundles";
 import { AxiosResponse } from "axios";
 import Utils from "./utils";
 import Api from "./api";
-import { CreateAndUploadOptions, Currency, Manifest, UploadOptions, UploadResponse } from "./types";
+import { CreateAndUploadOptions, Currency, Manifest, UploadOptions, UploadReceipt, UploadResponse } from "./types";
 import PromisePool from "@supercharge/promise-pool/dist";
 import retry from "async-retry";
 import { ChunkingUploader } from "./chunkingUploader";
@@ -48,7 +48,7 @@ export default class Uploader {
             });
             if (res.status == 201) {
                 if (opts?.getReceiptSignature === true) { throw new Error(res.data as any as string); }
-                res.data = { id: transaction.id };
+                res.data = { id: transaction.id, timestamp: Date.now() };
             }
         }
         switch (res.status) {
@@ -60,7 +60,7 @@ export default class Uploader {
                 }
         }
         if (opts?.getReceiptSignature) {
-            res.data.verify = Utils.verifyReceipt.bind({}, res.data);
+            (res.data as UploadReceipt).verify = Utils.verifyReceipt.bind({}, res.data);
         }
         return res;
     }

--- a/src/node/bundlr.ts
+++ b/src/node/bundlr.ts
@@ -1,7 +1,7 @@
 import Api from "../common/api";
 import Bundlr from "../common/bundlr";
 import Fund from "../common/fund";
-import { CreateAndUploadOptions, UploadResponse } from "../common/types";
+import { CreateAndUploadOptions, UploadReceipt, UploadResponse } from "../common/types";
 import Utils from "../common/utils";
 import getCurrency from "./currencies";
 import { NodeCurrency } from "./types";
@@ -36,7 +36,7 @@ export default class NodeBundlr extends Bundlr {
     * @param path path to the file to upload
     * @returns bundler response
     */
-    async uploadFile(path: string, opts?: CreateAndUploadOptions): Promise<UploadResponse> {
+    async uploadFile(path: string, opts?: CreateAndUploadOptions): Promise<UploadResponse | UploadReceipt> {
         return this.uploader.uploadFile(path, opts);
     };
 

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -1,5 +1,5 @@
 import { promises, PathLike, createReadStream, createWriteStream } from "fs";
-import { CreateAndUploadOptions, Currency, UploadResponse } from "../common/types";
+import { CreateAndUploadOptions, Currency, UploadReceipt, UploadResponse } from "../common/types";
 import Uploader from "../common/upload";
 import Api from "../common/api";
 import Utils from "../common/utils";
@@ -22,7 +22,7 @@ export default class NodeUploader extends Uploader {
      * @param path to the file to be uploaded
      * @returns the response from the bundler
      */
-    public async uploadFile(path: string, opts?: CreateAndUploadOptions): Promise<UploadResponse> {
+    public async uploadFile(path: string, opts?: CreateAndUploadOptions): Promise<UploadResponse | UploadReceipt> {
         if (!promises.stat(path).then(_ => true).catch(_ => false)) {
             throw new Error(`Unable to access path: ${path}`);
         }


### PR DESCRIPTION
This PR renovates the UploadResponse type (+ applicable related code) to be an OR between UploadResponseBase (always fields) and UploadReceipt (optional receipt fields)