### PR TITLE
feat: :sparkles: Add client side withdrawal polling

### DIFF
--- a/src/common/fund.ts
+++ b/src/common/fund.ts
@@ -75,4 +75,8 @@ export default class Fund {
       },
     );
   }
+
+  public async submitFundTransaction(transactionId: string): Promise<AxiosResponse> {
+    return this.submitTransaction(transactionId);
+  }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -85,12 +85,13 @@ export default class Utils {
    * @param txid
    * @returns
    */
-  public async confirmationPoll(txid: string): Promise<any> {
+  public async confirmationPoll(txid: string, seconds = 30): Promise<any> {
     if (this.currencyConfig.isSlow) {
       return;
     }
+    if (seconds < 0) seconds = 0;
     let lastError;
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < seconds; i++) {
       await sleep(1000);
       if (
         await this.currencyConfig


### PR DESCRIPTION
Adds client side failed/timed out withdrawal polling, so transactions that take longer than the node timeout can be proactively confirmed.