### PR TITLE
Pass user tags to upload folder verified

### DIFF
--- a/src/node/bundlr.ts
+++ b/src/node/bundlr.ts
@@ -73,17 +73,17 @@ export default class NodeBundlr extends Bundlr {
       indexFile,
       interactivePreflight,
       logFunction,
-      userTags,
+      manifestTags,
     }: {
       batchSize?: number;
       keepDeleted?: boolean;
       indexFile?: string;
       interactivePreflight?: boolean;
       logFunction?: (log: string) => Promise<void>;
-      userTags?: { name: string, value: string }[]
+      manifestTags?: { name: string, value: string }[]
     } = {},
   ): Promise<UploadResponse | undefined> {
-    return this.uploader.uploadFolder(path, { indexFile, batchSize, interactivePreflight, keepDeleted, logFunction, userTags });
+    return this.uploader.uploadFolder(path, { indexFile, batchSize, interactivePreflight, keepDeleted, logFunction, manifestTags });
   }
   public static async init(opts: {
     url: string;

--- a/src/node/bundlr.ts
+++ b/src/node/bundlr.ts
@@ -63,6 +63,7 @@ export default class NodeBundlr extends Bundlr {
    * @param interactivePreflight - whether to interactively prompt the user for confirmation of upload (CLI ONLY)
    * @param keepDeleted - Whether to keep previously uploaded (but now deleted) files in the manifest
    * @param logFunction - for handling logging from the uploader for UX
+   * @param manifestTags - For allowing the caller to pass tags that will be added to the manifest transaction.
    * @returns
    */
   public async uploadFolder(
@@ -80,7 +81,7 @@ export default class NodeBundlr extends Bundlr {
       indexFile?: string;
       interactivePreflight?: boolean;
       logFunction?: (log: string) => Promise<void>;
-      manifestTags?: { name: string, value: string }[]
+      manifestTags?: { name: string; value: string }[];
     } = {},
   ): Promise<UploadResponse | undefined> {
     return this.uploader.uploadFolder(path, { indexFile, batchSize, interactivePreflight, keepDeleted, logFunction, manifestTags });

--- a/src/node/bundlr.ts
+++ b/src/node/bundlr.ts
@@ -73,15 +73,17 @@ export default class NodeBundlr extends Bundlr {
       indexFile,
       interactivePreflight,
       logFunction,
+      userTags,
     }: {
       batchSize?: number;
       keepDeleted?: boolean;
       indexFile?: string;
       interactivePreflight?: boolean;
       logFunction?: (log: string) => Promise<void>;
+      userTags?: { name: string, value: string }[]
     } = {},
   ): Promise<UploadResponse | undefined> {
-    return this.uploader.uploadFolder(path, { indexFile, batchSize, interactivePreflight, keepDeleted, logFunction });
+    return this.uploader.uploadFolder(path, { indexFile, batchSize, interactivePreflight, keepDeleted, logFunction, userTags });
   }
   public static async init(opts: {
     url: string;

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -216,8 +216,8 @@ export default class NodeUploader extends Uploader {
     const tags = [
       { name: "Type", value: "manifest" },
       { name: "Content-Type", value: "application/x.arweave-manifest+json" },
+      ...manifestTags || [] // Added the || [] because I was getting a type error
     ];
-    manifestTags?.forEach(t => tags.push(t))
     const mres = await this.uploadData(createReadStream(jsonManifestPath), { tags }).catch((e) => {
       throw new Error(`Failed to upload manifest: ${e.message}`);
     });

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -72,14 +72,14 @@ export default class NodeUploader extends Uploader {
       indexFile,
       interactivePreflight,
       logFunction,
-      userTags,
+      manifestTags,
     }: {
       batchSize: number;
       keepDeleted: boolean;
       indexFile?: string;
       interactivePreflight?: boolean;
       logFunction?: (log: string) => Promise<void>;
-      userTags?: { name: string, value: string}[];
+      manifestTags?: { name: string, value: string}[];
     } = { batchSize: 10, keepDeleted: true },
   ): Promise<UploadResponse | undefined> {
     path = resolve(path);
@@ -217,7 +217,7 @@ export default class NodeUploader extends Uploader {
       { name: "Type", value: "manifest" },
       { name: "Content-Type", value: "application/x.arweave-manifest+json" },
     ];
-    userTags?.forEach(t => tags.push(t))
+    manifestTags?.forEach(t => tags.push(t))
     const mres = await this.uploadData(createReadStream(jsonManifestPath), { tags }).catch((e) => {
       throw new Error(`Failed to upload manifest: ${e.message}`);
     });

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -79,7 +79,7 @@ export default class NodeUploader extends Uploader {
       indexFile?: string;
       interactivePreflight?: boolean;
       logFunction?: (log: string) => Promise<void>;
-      manifestTags?: { name: string, value: string}[];
+      manifestTags?: { name: string; value: string }[];
     } = { batchSize: 10, keepDeleted: true },
   ): Promise<UploadResponse | undefined> {
     path = resolve(path);
@@ -216,7 +216,7 @@ export default class NodeUploader extends Uploader {
     const tags = [
       { name: "Type", value: "manifest" },
       { name: "Content-Type", value: "application/x.arweave-manifest+json" },
-      ...manifestTags || [] // Added the || [] because I was getting a type error
+      ...(manifestTags ?? []),
     ];
     const mres = await this.uploadData(createReadStream(jsonManifestPath), { tags }).catch((e) => {
       throw new Error(`Failed to upload manifest: ${e.message}`);

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -72,12 +72,14 @@ export default class NodeUploader extends Uploader {
       indexFile,
       interactivePreflight,
       logFunction,
+      userTags,
     }: {
       batchSize: number;
       keepDeleted: boolean;
       indexFile?: string;
       interactivePreflight?: boolean;
       logFunction?: (log: string) => Promise<void>;
+      userTags?: { name: string, value: string}[];
     } = { batchSize: 10, keepDeleted: true },
   ): Promise<UploadResponse | undefined> {
     path = resolve(path);
@@ -215,6 +217,7 @@ export default class NodeUploader extends Uploader {
       { name: "Type", value: "manifest" },
       { name: "Content-Type", value: "application/x.arweave-manifest+json" },
     ];
+    userTags?.forEach(t => tags.push(t))
     const mres = await this.uploadData(createReadStream(jsonManifestPath), { tags }).catch((e) => {
       throw new Error(`Failed to upload manifest: ${e.message}`);
     });


### PR DESCRIPTION
Hey @joshbenaron @JesseTheRobot 

The previous PR was saying the commits needed to be verified to get merged into the default branch.  Had to setup some keys and rebase this branch to get the commits verified.

There are no changes between this branch and `pass-user-tags-to-upload-folder` except that the commits are verified commits now.

<img width="920" alt="image" src="https://user-images.githubusercontent.com/105590998/226186522-5d8d069e-950f-4889-b1c9-164404e53f75.png">

