### PR TITLE
Feat/version header

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "lint:check": "eslint src/**",
     "lint:fix": "eslint src/** --fix",
     "watch": "tsc --watch -p tsconfig.json & webpack --watch",
-    "webpack:analyze": "webpack --profile --json /tmp/wp.json && webpack-bundle-analyzer /tmp/wp.json"
+    "webpack:analyze": "webpack --profile --json /tmp/wp.json && webpack-bundle-analyzer /tmp/wp.json",
+    "prepack": "yarn ts-node ./scripts/embedVersion.ts"
   },
   "bin": {
     "bundlr": "./build/cjs/node/cli.js",

--- a/scripts/embedVersion.ts
+++ b/scripts/embedVersion.ts
@@ -1,0 +1,19 @@
+import { resolve } from "path";
+import { readFileSync } from "fs";
+import Bundlr from "../src/common/bundlr";
+import { readFile, writeFile } from "fs/promises";
+const version = JSON.parse(readFileSync("./package.json", { encoding: "utf-8" })).version;
+const paths = ["./bundle.js", "./cjs/common/bundlr.js", "./esm/common/bundlr.js"];
+(async function (): Promise<void> {
+  const dir = resolve("./build");
+  await Promise.all(
+    paths.map((p) =>
+      (async (): Promise<void> => {
+        const path = resolve(dir, p);
+        const content = await readFile(path, { encoding: "utf-8" });
+        const newContent = content.replace(Bundlr.VERSION, version);
+        await writeFile(path, newContent, { encoding: "utf-8" });
+      })(),
+    ),
+  );
+})();

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -60,7 +60,7 @@ export default class Api {
       timeout: config.timeout ?? 20000,
       logging: config.logging ?? false,
       logger: config.logger ?? console.log,
-      headers: { ...config.headers, "bundlr-js-sdk-version": Bundlr.VERSION },
+      headers: { ...config.headers, "x-bundlr-js-sdk-version": Bundlr.VERSION },
       withCredentials: true,
     };
   }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { AxiosResponse, AxiosRequestConfig, AxiosInstance } from "axios";
 import Axios from "axios";
+import Bundlr from "./bundlr";
 
 // taken from the arweave.js lib
 export interface ApiConfig {
@@ -59,7 +60,7 @@ export default class Api {
       timeout: config.timeout ?? 20000,
       logging: config.logging ?? false,
       logger: config.logger ?? console.log,
-      headers: config.headers ?? {},
+      headers: { ...config.headers, "bundlr-js-sdk-version": Bundlr.VERSION },
       withCredentials: true,
     };
   }

--- a/src/common/bundlr.ts
+++ b/src/common/bundlr.ts
@@ -29,7 +29,7 @@ export default abstract class Bundlr {
   public currencyConfig!: Currency;
   protected _readyPromise: Promise<void> | undefined;
   public url: URL;
-
+  static VERSION = "REPLACEMEBUNDLRVERSION";
   constructor(url) {
     this.url = url;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-export { default } from "./node";
+import NodeBundlr from "./node";
+export default NodeBundlr;
 export { default as WebBundlr } from "./web";

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -4,7 +4,6 @@ import { Command } from "commander";
 import { readFileSync } from "fs";
 import Bundlr from "./bundlr";
 import inquirer from "inquirer";
-import { execSync } from "child_process";
 import BigNumber from "bignumber.js";
 import { checkPath } from "./upload";
 import type NodeBundlr from "./bundlr";
@@ -39,11 +38,7 @@ program
   .option("--force-chunking", "Forces usage of chunking for all files regardless of size");
 // Define commands
 // uses NPM view to query the package's version.
-program.version(
-  execSync("npm view @bundlr-network/client version").toString().replace("\n", ""),
-  "-v, --version",
-  "Gets the current package version of the bundlr client",
-);
+program.version(Bundlr.VERSION, "-v, --version", "Gets the current package version of the bundlr client");
 
 // Balance command - gets the provided address' balance on the specified bundler
 program


### PR DESCRIPTION
This PR:

- Adds the `bundlr-js-sdk-version` header to requests made by the internal client API for improved diagnostics.
- adds a static `version` property to `Bundlr`, as well as a publish-time script that injects the latest version into the code before release (after the package.json version field has been updated).