### PR TITLE
fix: :bug: Algorand: remove URL parsing logic, require new opts.indexerUrl

### DIFF
--- a/src/cjsIndex.ts
+++ b/src/cjsIndex.ts
@@ -4,7 +4,7 @@ import WebBundlr from "./web/index";
 // this class allows for CJS imports without .default, as well as still allowing for destructured Node/WebBundlr imports.
 class IndexBundlr extends NodeBundlr {
   static default = IndexBundlr;
-  static NodeBundlr = WebBundlr;
+  static NodeBundlr = NodeBundlr;
   static WebBundlr = WebBundlr;
 }
 export = IndexBundlr;

--- a/src/node/currencies/algorand.ts
+++ b/src/node/currencies/algorand.ts
@@ -18,8 +18,9 @@ export default class AlgorandConfig extends BaseNodeCurrency {
     super(config);
     this.base = ["microAlgos", 1e6];
     this.keyPair = mnemonicToSecretKey(this.wallet);
-    this.apiURL = this.providerUrl.slice(0, 8) + "node." + this.providerUrl.slice(8);
-    this.indexerURL = this.providerUrl.slice(0, 8) + "algoindexer." + this.providerUrl.slice(8);
+    this.apiURL = config.providerUrl;
+    if (!config.opts.indexerUrl) throw new Error(`Algorand: required client constructor option 'opts.indexerUrl' is undefined`);
+    this.indexerURL = config.opts.indexerUrl;
   }
 
   async getTx(txId: string): Promise<Tx> {

--- a/src/node/currencies/index.ts
+++ b/src/node/currencies/index.ts
@@ -159,7 +159,14 @@ export default function getCurrency(
       });
     }
     case "algorand": {
-      return new AlgorandConfig({ bundlr, name: "algorand", ticker: "ALGO", providerUrl: providerUrl ?? "https://algoexplorerapi.io", wallet, opts });
+      return new AlgorandConfig({
+        bundlr,
+        name: "algorand",
+        ticker: "ALGO",
+        providerUrl: providerUrl ?? "https://mainnet-api.algonode.cloud",
+        wallet,
+        opts: { indexerUrl: "https://mainnet-idx.algonode.cloud", ...opts },
+      });
     }
     case "aptos": {
       return new AptosConfig({


### PR DESCRIPTION
This PR fixes an issue caused by the default algorand nodes going offline, which in turn caused  an issue with the internal API and indexer URL extraction code.
Now, users can provider the API URL as providerUrl, and the indexerUrl as `opts.indexerUrl` - Algorand will throw if this is not present. Sensible default RPC URLs have been updated.