### PR TITLE
Feat/estimate folder price

### DIFF
--- a/src/cjsIndex.ts
+++ b/src/cjsIndex.ts
@@ -1,4 +1,5 @@
-import "./common/hack.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as _ from "./common/hack";
 import NodeBundlr from "./node/index";
 import WebBundlr from "./web/index";
 

--- a/src/esmIndex.ts
+++ b/src/esmIndex.ts
@@ -1,4 +1,5 @@
-import "./common/hack.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as _ from "./common/hack";
 import NB from "./node/bundlr";
 export { default as WebBundlr } from "./web/bundlr";
 export const NodeBundlr = NB;

--- a/src/node/bundlr.ts
+++ b/src/node/bundlr.ts
@@ -1,4 +1,5 @@
-import "../common/hack.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as _ from "../common/hack";
 import Api from "../common/api";
 import Bundlr from "../common/bundlr";
 import Fund from "../common/fund";

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -188,9 +188,11 @@ export default class NodeUploader extends Uploader {
       return await uploadManifest(logFunction);
     }
 
-    const zprice = (await this.utils.getPrice(this.currency, 0)).multipliedBy(files.length);
+    // const zprice = (await this.utils.getPrice(this.currency, 0)).multipliedBy(files.length);
 
-    const price = (await this.utils.getPrice(this.currency, total)).plus(zprice).toFixed(0);
+    // const price = (await this.utils.getPrice(this.currency, total)).plus(zprice).toFixed(0);
+
+    const price = await this.utils.estimateFolderPrice({ fileCount: files.length, totalBytes: total });
 
     if (interactivePreflight) {
       if (

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -45,8 +45,7 @@ export default class NodeUploader extends Uploader {
     return await this.uploadData(data, opts);
   }
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  private async *walk(dir: string) {
+  public async *walk(dir: string): AsyncGenerator<string, void, any> {
     for await (const d of await promises.opendir(dir)) {
       const entry = join(dir, d.name);
       if (d.isDirectory()) yield* await this.walk(entry);

--- a/src/web/bundlr.ts
+++ b/src/web/bundlr.ts
@@ -1,4 +1,5 @@
-import "../common/hack.js";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as _ from "../common/hack";
 import type { BundlrConfig } from "../common/types";
 import Api from "../common/api";
 import Bundlr from "../common/bundlr";


### PR DESCRIPTION
This PR adds a new method `estimateFolderPrice` to `utils` - this method can take either an array of JSON abstract representation of a folder and produce a accurate estimate for the cost to upload the entire folder