### PR TITLE
feat: :sparkles: web/upload: Add uploadFolder support

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,5 +1,5 @@
 import type BigNumber from "bignumber.js";
-import type { DataItem, Signer, createData, deepHash, getCryptoDriver, stringToBuffer, DataItemCreateOptions } from "arbundles";
+import type { DataItem, Signer, createData, deepHash, getCryptoDriver, stringToBuffer, DataItemCreateOptions, bundleAndSignData } from "arbundles";
 import type { FileDataItem } from "arbundles/file";
 import type Bundlr from "./bundlr";
 
@@ -17,6 +17,7 @@ export interface Arbundles {
   deepHash: typeof deepHash;
   stringToBuffer: typeof stringToBuffer;
   getCryptoDriver: typeof getCryptoDriver;
+  bundleAndSignData: typeof bundleAndSignData;
 }
 
 export interface BundlrTransaction extends DataItem {

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -191,16 +191,16 @@ export default class Uploader {
     this.contentTypeOverride = type;
   }
 
-  uploadMany(
+  uploadBundle(
     transactions: (DataItem | Buffer | string)[],
     opts: UploadOptions & { getReceiptSignature: true; ephemeralKey?: JWKInterface },
   ): Promise<AxiosResponse<UploadReceipt> & { ephemeralKey: JWKInterface; ephemeralAddress: string; txs: string[] }>;
-  uploadMany(
+  uploadBundle(
     transactions: (DataItem | Buffer)[],
     opts?: UploadOptions & { ephemeralKey?: JWKInterface },
   ): Promise<AxiosResponse<UploadResponse> & { ephemeralKey: JWKInterface; ephemeralAddress: string; txs: string[] }>;
 
-  public async uploadMany(
+  public async uploadBundle(
     transactions: (DataItem | Buffer)[],
     opts?: UploadOptions & { ephemeralKey?: JWKInterface },
   ): Promise<AxiosResponse<UploadResponse> & { ephemeralKey: JWKInterface; ephemeralAddress: string; txs: string[] }> {

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -194,16 +194,23 @@ export default class Uploader {
   uploadBundle(
     transactions: (DataItem | Buffer | string)[],
     opts: UploadOptions & { getReceiptSignature: true; throwawayKey?: JWKInterface },
-  ): Promise<AxiosResponse<UploadReceipt> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: string[] }>;
+  ): Promise<AxiosResponse<UploadReceipt> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: DataItem[] }>;
   uploadBundle(
     transactions: (DataItem | Buffer)[],
     opts?: UploadOptions & { throwawayKey?: JWKInterface },
-  ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: string[] }>;
+  ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: DataItem[] }>;
 
+  /**
+   * Uploads a list of transactions as a nested bundle using a temporary (throwaway) key
+   *
+   * @param transactions List of transactions (DataItems/Raw data buffers) to bundle
+   * @param opts Standard upload options, plus the `throwawayKey` paramter, for passing your own throwaway JWK
+   * @returns Standard upload response from the bundler node, plus the throwaway key & address, manifest, and the list of bundled DataItems
+   */
   public async uploadBundle(
     transactions: (DataItem | Buffer)[],
     opts?: UploadOptions & { throwawayKey?: JWKInterface },
-  ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: string[] }> {
+  ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: DataItem[] }> {
     const throwawayKey = opts?.throwawayKey ?? (await this.arbundles.getCryptoDriver().generateJWK());
     const ephemeralSigner = new ArweaveSigner(throwawayKey);
     const txs = transactions.map((tx) => (this.arbundles.DataItem.isDataItem(tx) ? tx : this.arbundles.createData(tx, ephemeralSigner)));
@@ -223,6 +230,6 @@ export default class Uploader {
       Buffer.from(await this.arbundles.getCryptoDriver().hash(base64url.toBuffer(base64url(ephemeralSigner.publicKey)))),
     );
 
-    return { ...res, txs: bundle.getIds(), throwawayKey, throwawayKeyAddress };
+    return { ...res, txs, throwawayKey, throwawayKeyAddress };
   }
 }

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -191,6 +191,17 @@ export default class Uploader {
     this.contentTypeOverride = type;
   }
 
+  /**
+   * Creates & Uploads a [nested bundle](https://docs.bundlr.network/faqs/dev-faq#what-is-a-nested-bundle) from the provided list of transactions. \
+   * NOTE: If a provided transaction is unsigned, the transaction is signed using a temporary (throwaway) Arweave key. \
+   * This means transactions can be associated with a single "random" address. \
+   * NOTE: If a Buffer is provided, it is converted into a transaction and then signed by the throwaway key. \
+   * The throwaway key, address, and all bundled (provided + throwaway signed + generated) transactions are returned by this method.
+   *
+   * @param transactions List of transactions (DataItems/Raw data buffers) to bundle
+   * @param opts Standard upload options, plus the `throwawayKey` paramter, for passing your own throwaway JWK
+   * @returns Standard upload response from the bundler node, plus the throwaway key & address, and the list of bundled transactions
+   */
   uploadBundle(
     transactions: (DataItem | Buffer | string)[],
     opts: UploadOptions & { getReceiptSignature: true; throwawayKey?: JWKInterface },
@@ -200,13 +211,6 @@ export default class Uploader {
     opts?: UploadOptions & { throwawayKey?: JWKInterface },
   ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: DataItem[] }>;
 
-  /**
-   * Uploads a list of transactions as a nested bundle using a temporary (throwaway) key
-   *
-   * @param transactions List of transactions (DataItems/Raw data buffers) to bundle
-   * @param opts Standard upload options, plus the `throwawayKey` paramter, for passing your own throwaway JWK
-   * @returns Standard upload response from the bundler node, plus the throwaway key & address, manifest, and the list of bundled DataItems
-   */
   public async uploadBundle(
     transactions: (BundlrTransaction | DataItem | Buffer)[],
     opts?: UploadOptions & { throwawayKey?: JWKInterface },

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -193,19 +193,19 @@ export default class Uploader {
 
   uploadBundle(
     transactions: (DataItem | Buffer | string)[],
-    opts: UploadOptions & { getReceiptSignature: true; ephemeralKey?: JWKInterface },
-  ): Promise<AxiosResponse<UploadReceipt> & { ephemeralKey: JWKInterface; ephemeralAddress: string; txs: string[] }>;
+    opts: UploadOptions & { getReceiptSignature: true; throwawayKey?: JWKInterface },
+  ): Promise<AxiosResponse<UploadReceipt> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: string[] }>;
   uploadBundle(
     transactions: (DataItem | Buffer)[],
-    opts?: UploadOptions & { ephemeralKey?: JWKInterface },
-  ): Promise<AxiosResponse<UploadResponse> & { ephemeralKey: JWKInterface; ephemeralAddress: string; txs: string[] }>;
+    opts?: UploadOptions & { throwawayKey?: JWKInterface },
+  ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: string[] }>;
 
   public async uploadBundle(
     transactions: (DataItem | Buffer)[],
-    opts?: UploadOptions & { ephemeralKey?: JWKInterface },
-  ): Promise<AxiosResponse<UploadResponse> & { ephemeralKey: JWKInterface; ephemeralAddress: string; txs: string[] }> {
-    const ephemeralKey = opts?.ephemeralKey ?? (await this.arbundles.getCryptoDriver().generateJWK());
-    const ephemeralSigner = new ArweaveSigner(ephemeralKey);
+    opts?: UploadOptions & { throwawayKey?: JWKInterface },
+  ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: string[] }> {
+    const throwawayKey = opts?.throwawayKey ?? (await this.arbundles.getCryptoDriver().generateJWK());
+    const ephemeralSigner = new ArweaveSigner(throwawayKey);
     const txs = transactions.map((tx) => (this.arbundles.DataItem.isDataItem(tx) ? tx : this.arbundles.createData(tx, ephemeralSigner)));
     const bundle = await this.arbundles.bundleAndSignData(txs, ephemeralSigner);
 
@@ -219,10 +219,10 @@ export default class Uploader {
     await tx.sign(this.currencyConfig.getSigner());
 
     const res = await this.uploadTransaction(tx, opts);
-    const ephemeralAddress = base64url(
+    const throwawayKeyAddress = base64url(
       Buffer.from(await this.arbundles.getCryptoDriver().hash(base64url.toBuffer(base64url(ephemeralSigner.publicKey)))),
     );
 
-    return { ...res, txs: bundle.getIds(), ephemeralKey, ephemeralAddress };
+    return { ...res, txs: bundle.getIds(), throwawayKey, throwawayKeyAddress };
   }
 }

--- a/src/common/upload.ts
+++ b/src/common/upload.ts
@@ -1,7 +1,7 @@
 import type { AxiosResponse } from "axios";
 import type Utils from "./utils";
 import type Api from "./api";
-import type { Arbundles, CreateAndUploadOptions, Currency, Manifest, UploadOptions, UploadReceipt, UploadResponse } from "./types";
+import type { Arbundles, BundlrTransaction, CreateAndUploadOptions, Currency, Manifest, UploadOptions, UploadReceipt, UploadResponse } from "./types";
 import { PromisePool } from "@supercharge/promise-pool";
 import retry from "async-retry";
 import { ChunkingUploader } from "./chunkingUploader";
@@ -208,7 +208,7 @@ export default class Uploader {
    * @returns Standard upload response from the bundler node, plus the throwaway key & address, manifest, and the list of bundled DataItems
    */
   public async uploadBundle(
-    transactions: (DataItem | Buffer)[],
+    transactions: (BundlrTransaction | DataItem | Buffer)[],
     opts?: UploadOptions & { throwawayKey?: JWKInterface },
   ): Promise<AxiosResponse<UploadResponse> & { throwawayKey: JWKInterface; throwawayKeyAddress: string; txs: DataItem[] }> {
     const throwawayKey = opts?.throwawayKey ?? (await this.arbundles.getCryptoDriver().generateJWK());

--- a/src/node/bundlr.ts
+++ b/src/node/bundlr.ts
@@ -10,7 +10,7 @@ import type { NodeCurrency } from "./types";
 import NodeUploader from "./upload";
 import * as arbundles from "./utils";
 
-export default class NodeBundlr extends Bundlr {
+export class NodeBundlr extends Bundlr {
   public uploader: NodeUploader; // re-define type
   public currencyConfig: NodeCurrency;
 
@@ -111,3 +111,4 @@ export default class NodeBundlr extends Bundlr {
     return bundlr;
   }
 }
+export default NodeBundlr;

--- a/src/node/upload.ts
+++ b/src/node/upload.ts
@@ -65,7 +65,7 @@ export default class NodeUploader extends Uploader {
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
   public async uploadFolder(
-    path,
+    path: string,
     {
       batchSize = 10,
       keepDeleted = true,

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -1,2 +1,2 @@
-import { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver /* Arweave */ } from "arbundles/node";
-export { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver /* Arweave */ };
+import { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver, bundleAndSignData /* Arweave */ } from "arbundles/node";
+export { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver, bundleAndSignData /* Arweave */ };

--- a/src/web/bundlr.ts
+++ b/src/web/bundlr.ts
@@ -4,15 +4,17 @@ import type { BundlrConfig } from "../common/types";
 import Api from "../common/api";
 import Bundlr from "../common/bundlr";
 import Fund from "../common/fund";
-import Uploader from "../common/upload";
 import Utils from "../common/utils";
 import getCurrency from "./currencies/index";
 // import WebFund from "./fund";
 import type { WebCurrency } from "./types";
 import * as arbundles from "./utils";
+import { WebUploader } from "./upload";
 
-export default class WebBundlr extends Bundlr {
+export class WebBundlr extends Bundlr {
   public currencyConfig: WebCurrency;
+  public uploader: WebUploader;
+  uploadFolder: InstanceType<typeof WebUploader>["uploadFolder"];
 
   constructor(url: string, currency: string, provider?: any, config?: BundlrConfig) {
     const parsed = new URL(url);
@@ -32,8 +34,10 @@ export default class WebBundlr extends Bundlr {
     if (parsed.host === "devnet.bundlr.network" && !(config?.providerUrl || this.currencyConfig.inheritsRPC))
       throw new Error(`Using ${parsed.host} requires a dev/testnet RPC to be configured! see https://docs.bundlr.network/sdk/using-devnet`);
     this.utils = new Utils(this.api, this.currency, this.currencyConfig);
-    this.uploader = new Uploader(this.api, this.utils, this.currency, this.currencyConfig);
+    this.uploader = new WebUploader(this);
     this.funder = new Fund(this.utils);
     this.address = "Please run `await bundlr.ready()`";
+    this.uploadFolder = this.uploader.uploadFolder;
   }
 }
+export default WebBundlr;

--- a/src/web/currencies/index.ts
+++ b/src/web/currencies/index.ts
@@ -7,7 +7,7 @@ import ERC20Config from "./erc20";
 import axios from "axios";
 import utils from "../../common/utils";
 import AptosConfig from "./aptos";
-import type WebBundlr from "web";
+import type WebBundlr from "../";
 // import ArweaveConfig from "./arweave";
 
 export default function getCurrency(

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -10,14 +10,21 @@ export class WebUploader extends Uploader {
     super(bundlr.api, bundlr.utils, bundlr.currency, bundlr.currencyConfig);
     this.bundlr = bundlr;
   }
-
+  /**
+   * Uploads a list of `File` objects & a generated folder manifest as a nested bundle using a temporary signing key.
+   *
+   * @param files list of `File` objects to upload - note: this code determines the paths via the File's `webkitRelativePath` property
+   * @param {string} [opts.indexFileRelPath] Relative path for the index file, i.e `folder/index.html`
+   * @param {string} [opts.manifestTags] List of tags to add onto the manifest transaction
+   * @returns Standard upload response from the bundler node, plus the throwaway key & address, manifest, and the list of generated transactions
+   */
   public async uploadFolder(
     files: File[],
     opts?: {
       indexFileRelPath?: string;
       manifestTags?: Tag[];
     },
-  ): Promise<(UploadResponse & { throwawayKey: JWKInterface; txs: string[]; throwawayKeyAddress: string; manifest: Manifest }) | undefined> {
+  ): Promise<(UploadResponse & { throwawayKey: JWKInterface; txs: DataItem[]; throwawayKeyAddress: string; manifest: Manifest }) | undefined> {
     const txs: DataItem[] = [];
     const txMap = new Map();
     const throwawayKey = await this.bundlr.arbundles.getCryptoDriver().generateJWK();

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -17,11 +17,11 @@ export class WebUploader extends Uploader {
       indexFileRelPath?: string;
       manifestTags?: Tag[];
     },
-  ): Promise<(UploadResponse & { ephemeralKey: JWKInterface; txs: string[]; ephemeralAddress: string; manifest: Manifest }) | undefined> {
+  ): Promise<(UploadResponse & { throwawayKey: JWKInterface; txs: string[]; throwawayKeyAddress: string; manifest: Manifest }) | undefined> {
     const txs: DataItem[] = [];
     const txMap = new Map();
-    const ephemeralKey = await this.bundlr.arbundles.getCryptoDriver().generateJWK();
-    const ephemeralSigner = new ArweaveSigner(ephemeralKey);
+    const throwawayKey = await this.bundlr.arbundles.getCryptoDriver().generateJWK();
+    const ephemeralSigner = new ArweaveSigner(throwawayKey);
     for (const file of files) {
       const path = file.webkitRelativePath;
       const tx = this.bundlr.arbundles.createData(Buffer.from(await file.arrayBuffer()), ephemeralSigner, {
@@ -43,7 +43,7 @@ export class WebUploader extends Uploader {
     await manifestTx.sign(ephemeralSigner);
     txs.push(manifestTx);
     // upload bundle
-    const bundleRes = await this.uploadBundle(txs, { ephemeralKey });
+    const bundleRes = await this.uploadBundle(txs, { throwawayKey });
 
     return { ...bundleRes, id: manifestTx.id, manifest };
   }

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -1,0 +1,50 @@
+import Uploader from "../common/upload";
+import type WebBundlr from "./bundlr";
+import type { Manifest, UploadResponse } from "../common/types";
+import type { DataItem, JWKInterface, Tag } from "arbundles";
+import { ArweaveSigner } from "arbundles";
+
+export class WebUploader extends Uploader {
+  protected bundlr: WebBundlr;
+  constructor(bundlr: WebBundlr) {
+    super(bundlr.api, bundlr.utils, bundlr.currency, bundlr.currencyConfig);
+    this.bundlr = bundlr;
+  }
+
+  public async uploadFolder(
+    files: File[],
+    opts?: {
+      indexFileRelPath?: string;
+      manifestTags?: Tag[];
+    },
+  ): Promise<(UploadResponse & { ephemeralKey: JWKInterface; txs: string[]; ephemeralAddress: string; manifest: Manifest }) | undefined> {
+    const txs: DataItem[] = [];
+    const txMap = new Map();
+    const ephemeralKey = await this.bundlr.arbundles.getCryptoDriver().generateJWK();
+    const ephemeralSigner = new ArweaveSigner(ephemeralKey);
+    for (const file of files) {
+      const path = file.webkitRelativePath;
+      const tx = this.bundlr.arbundles.createData(Buffer.from(await file.arrayBuffer()), ephemeralSigner, {
+        tags: [{ name: "Content-Type", value: file.type }],
+      });
+      await tx.sign(ephemeralSigner);
+      txs.push(tx);
+      txMap.set(path, tx.id);
+    }
+    // generate manifest, add to bundle
+    const manifest = await this.generateManifest({ items: txMap, indexFile: opts?.indexFileRelPath });
+    const manifestTx = this.bundlr.arbundles.createData(JSON.stringify(manifest), ephemeralSigner, {
+      tags: [
+        { name: "Type", value: "manifest" },
+        { name: "Content-Type", value: "application/x.arweave-manifest+json" },
+        ...(opts?.manifestTags ?? []),
+      ],
+    });
+    await manifestTx.sign(ephemeralSigner);
+    txs.push(manifestTx);
+    // upload bundle
+    const bundleRes = await this.uploadMany(txs, { ephemeralKey });
+
+    return { ...bundleRes, id: manifestTx.id, manifest };
+  }
+}

--- a/src/web/upload.ts
+++ b/src/web/upload.ts
@@ -43,7 +43,7 @@ export class WebUploader extends Uploader {
     await manifestTx.sign(ephemeralSigner);
     txs.push(manifestTx);
     // upload bundle
-    const bundleRes = await this.uploadMany(txs, { ephemeralKey });
+    const bundleRes = await this.uploadBundle(txs, { ephemeralKey });
 
     return { ...bundleRes, id: manifestTx.id, manifest };
   }

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -1,2 +1,2 @@
-import { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver /* Arweave */ } from "arbundles/web";
-export { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver /* Arweave */ };
+import { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver, bundleAndSignData /* Arweave */ } from "arbundles/web";
+export { createData, DataItem, deepHash, stringToBuffer, getCryptoDriver, bundleAndSignData /* Arweave */ };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noImplicitAny": false,
     "noImplicitThis": false,
     "strictNullChecks": true,
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "rootDir": ".",
     "experimentalDecorators": true,
     "paths": {


### PR DESCRIPTION
This PR adds `WebBundlr.uploadFolder`, which is able to upload a list of `File` objects as a folder (via a nested bundle + manifest with an ephemeral signing key)